### PR TITLE
use SSLContext instead of wrap_socket

### DIFF
--- a/secure-api/server.py
+++ b/secure-api/server.py
@@ -11,17 +11,21 @@ def run(server_class=HTTPServer, handler_class=SimpleHandler):
     server_address = ('', 8443)
     httpd = server_class(server_address, handler_class)
     
-    # Load the server certificate and private key with strict SSL/TLS
-    httpd.socket = ssl.wrap_socket(httpd.socket,
-                                   server_side=True,
-                                   certfile='./ssl/server.crt',
-                                   keyfile='./ssl/server.key',
-                                   ssl_version=ssl.PROTOCOL_TLS,
-                                   cert_reqs=ssl.CERT_REQUIRED,
-                                   ca_certs='./ssl/rootCA.crt')
+    # Create SSL context
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    
+    # Load the server certificate and private key
+    context.load_cert_chain(certfile='./ssl/server.crt', keyfile='./ssl/server.key')
+    
+    # Set client certificate requirements and CA certificate file
+    context.verify_mode = ssl.CERT_REQUIRED
+    context.load_verify_locations(cafile='./ssl/rootCA.crt')
+    
+    # Wrap the server socket with SSL
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     
     print('Starting https server on port 8443...')
     httpd.serve_forever()
 
 if __name__ == '__main__':
-    run()
+    run()    


### PR DESCRIPTION
Previous Code: Uses ssl.wrap_socket 

This method is older and has been deprecated in newer versions of Python
so the server.py not work correctly

Updated Code: Uses SSLContext

It provides a more flexible and robust way to configure SSL/TLS settings